### PR TITLE
feat(megatron): add model and pretrain config for LLaMA3.1-405B

### DIFF
--- a/examples/megatron/configs/llama3.1_405B-pretrain.yaml
+++ b/examples/megatron/configs/llama3.1_405B-pretrain.yaml
@@ -7,7 +7,7 @@ modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    model: llama3.1_70B.yaml
+    model: llama3.1_405B.yaml
     overrides:
       # log
       wandb_project: "Primus_DeepSeek_Pretrain"

--- a/examples/megatron/configs/llama3.1_405B-pretrain.yaml
+++ b/examples/megatron/configs/llama3.1_405B-pretrain.yaml
@@ -59,15 +59,14 @@ modules:
       no_save_rng: null
       disable_last_saving: true
 
-      use_torch_fsdp2: true
-      use_distributed_optimizer: false
-      overlap_param_gather: false
+      use_torch_fsdp2: false
+      use_distributed_optimizer: true
+      overlap_param_gather: true
       ckpt_format: torch_dist
       sequence_parallel: 1
-      gradient_accumulation_fusion: false
-      #deprecated_use_mcore_models: true
+      gradient_accumulation_fusion: true
 
       # recompute
-      recompute_granularity: full # full, selective
-      recompute_method: block # uniform, block
-      recompute_num_layers: 12 # int
+      # recompute_granularity: full # full, selective
+      # recompute_method: block # uniform, block
+      # recompute_num_layers: 12 # int

--- a/examples/megatron/configs/llama3.1_405B-pretrain.yaml
+++ b/examples/megatron/configs/llama3.1_405B-pretrain.yaml
@@ -63,7 +63,6 @@ modules:
       use_distributed_optimizer: true
       overlap_param_gather: true
       ckpt_format: torch_dist
-      sequence_parallel: 1
       gradient_accumulation_fusion: true
 
       # recompute

--- a/examples/megatron/configs/llama3.1_405B-pretrain.yaml
+++ b/examples/megatron/configs/llama3.1_405B-pretrain.yaml
@@ -36,8 +36,8 @@ modules:
       norm_epsilon: 1.0e-6
 
       # parallel
-      tensor_model_parallel_size: 1
-      pipeline_model_parallel_size: 1
+      tensor_model_parallel_size: 8
+      pipeline_model_parallel_size: 8
       expert_model_parallel_size: 1
       overlap_grad_reduce: true
 

--- a/examples/megatron/configs/llama3.1_405B-pretrain.yaml
+++ b/examples/megatron/configs/llama3.1_405B-pretrain.yaml
@@ -10,7 +10,7 @@ modules:
     model: llama3.1_405B.yaml
     overrides:
       # log
-      wandb_project: "Primus_DeepSeek_Pretrain"
+      wandb_project: "Primus_Pretrain"
       stderr_sink_level: DEBUG
 
       log_avg_skip_iterations: 2
@@ -39,7 +39,6 @@ modules:
       tensor_model_parallel_size: 8
       pipeline_model_parallel_size: 8
       expert_model_parallel_size: 1
-      overlap_grad_reduce: true
 
       # data
       mock_data: true
@@ -62,3 +61,4 @@ modules:
       use_distributed_optimizer: true
       overlap_param_gather: true
       gradient_accumulation_fusion: true
+      overlap_grad_reduce: true

--- a/examples/megatron/configs/llama3.1_405B-pretrain.yaml
+++ b/examples/megatron/configs/llama3.1_405B-pretrain.yaml
@@ -59,8 +59,6 @@ modules:
       no_save_rng: null
       disable_last_saving: true
 
-      use_torch_fsdp2: false
       use_distributed_optimizer: true
       overlap_param_gather: true
-      ckpt_format: torch_dist
       gradient_accumulation_fusion: true

--- a/examples/megatron/configs/llama3.1_405B-pretrain.yaml
+++ b/examples/megatron/configs/llama3.1_405B-pretrain.yaml
@@ -1,0 +1,73 @@
+work_group: ${TEAM:amd}
+user_name: ${USER:root}
+exp_name: exp-llama3_405B-pretrain
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+    model: llama3.1_70B.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_DeepSeek_Pretrain"
+      stderr_sink_level: DEBUG
+
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 5
+
+      train_iters: ${PRIMUS_TRAIN_ITERS:20}
+      micro_batch_size: ${PRIMUS_MBS:1}
+      global_batch_size: ${PRIMUS_GBS:256}
+
+      seq_length: ${PRIMUS_SEQ_LENGTH:8192}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:8192}
+
+      lr: 1.0e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1.0e-6
+
+      # parallel
+      tensor_model_parallel_size: 1
+      pipeline_model_parallel_size: 1
+      expert_model_parallel_size: 1
+      overlap_grad_reduce: true
+
+      # data
+      mock_data: true
+      train_data_path: ${TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
+      overlap_param_gather: false
+      ckpt_format: torch_dist
+      sequence_parallel: 1
+      gradient_accumulation_fusion: false
+      #deprecated_use_mcore_models: true
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 12 # int

--- a/examples/megatron/configs/llama3.1_405B-pretrain.yaml
+++ b/examples/megatron/configs/llama3.1_405B-pretrain.yaml
@@ -64,8 +64,3 @@ modules:
       overlap_param_gather: true
       ckpt_format: torch_dist
       gradient_accumulation_fusion: true
-
-      # recompute
-      # recompute_granularity: full # full, selective
-      # recompute_method: block # uniform, block
-      # recompute_num_layers: 12 # int


### PR DESCRIPTION
This PR adds support for pretraining LLaMA3.1–405B on Megatron backend by introducing a new model config and an example experiment YAML.