### PR TITLE
test(megatron): add Mixtral-8x22B/Mixtral-8x7B test and TRAIN_LOG override support

### DIFF
--- a/examples/run_pretrain.sh
+++ b/examples/run_pretrain.sh
@@ -96,7 +96,7 @@ if [ ! -f "${EXP}" ]; then
 fi
 
 
-TRAIN_LOG="output/log_torchrun_pretrain_$(basename "$EXP" .yaml).txt"
+TRAIN_LOG=${TRAIN_LOG:-"output/log_torchrun_pretrain_$(basename "$EXP" .yaml).txt"}
 
 LOG_INFO_RANK0 "==========Training info=========="
 LOG_INFO_RANK0 "EXP: $EXP"

--- a/tests/trainer/test_megatron_trainer.py
+++ b/tests/trainer/test_megatron_trainer.py
@@ -74,6 +74,19 @@ class TestMegatronTrainer(PrimusUT):
                 "PRIMUS_MODEL": "mixtral_8x7B_v0.1",
                 "PRIMUS_GLOBAL_BATCH_SIZE": "8",
                 "PRIMUS_EP": "8",
+                "PRIMUS_MOE_LAYER_FREQ": "1",
+                "PRIMUS_NUM_LAYERS": "4",
+            },
+        )
+
+    def test_mixtral_8x22B(self):
+        self._run_script(
+            "mixtral_8x22B_v0.1",
+            env_override={
+                "PRIMUS_MODEL": "mixtral_8x22B_v0.1",
+                "PRIMUS_GLOBAL_BATCH_SIZE": "8",
+                "PRIMUS_EP": "8",
+                "PRIMUS_MOE_LAYER_FREQ": "1",
                 "PRIMUS_NUM_LAYERS": "4",
             },
         )
@@ -109,6 +122,7 @@ class TestMegatronTrainer(PrimusUT):
         if env_override:
             env.update(env_override)
         env["EXP"] = "tests/trainer/test_megatron_trainer.yaml"
+        env["TRAIN_LOG"] = "ut_out/log.test_megatron_trainer.txt"
 
         do_print_at_runtime = False
         run_stdout = subprocess.PIPE if not do_print_at_runtime else sys.stdout

--- a/tests/trainer/test_megatron_trainer.py
+++ b/tests/trainer/test_megatron_trainer.py
@@ -29,7 +29,6 @@ class TestMegatronTrainer(PrimusUT):
         self._run_script(
             "llama2_7B",
             env_override={
-                "BACKEND": "megatron",
                 "PRIMUS_MODEL": "llama2_7B",
                 "PRIMUS_GLOBAL_BATCH_SIZE": "8",
                 "PRIMUS_NUM_LAYERS": "4",
@@ -40,7 +39,6 @@ class TestMegatronTrainer(PrimusUT):
         self._run_script(
             "llama3_8B",
             env_override={
-                "BACKEND": "megatron",
                 "PRIMUS_MODEL": "llama3_8B",
                 "PRIMUS_GLOBAL_BATCH_SIZE": "8",
                 "PRIMUS_NUM_LAYERS": "4",
@@ -51,7 +49,6 @@ class TestMegatronTrainer(PrimusUT):
         self._run_script(
             "llama3_70B",
             env_override={
-                "BACKEND": "megatron",
                 "PRIMUS_MODEL": "llama3_70B",
                 "PRIMUS_GLOBAL_BATCH_SIZE": "8",
                 "PRIMUS_NUM_LAYERS": "4",
@@ -62,10 +59,20 @@ class TestMegatronTrainer(PrimusUT):
         self._run_script(
             "deepseek_v2_lite",
             env_override={
-                "BACKEND": "megatron",
                 "PRIMUS_MODEL": "deepseek_v2_lite",
                 "PRIMUS_GLOBAL_BATCH_SIZE": "8",
                 "PRIMUS_MOE_LAYER_FREQ": "[0]*1+[1]*3",
+                "PRIMUS_EP": "8",
+                "PRIMUS_NUM_LAYERS": "4",
+            },
+        )
+
+    def test_mixtral_8x7B(self):
+        self._run_script(
+            "mixtral_8x7B_v0.1",
+            env_override={
+                "PRIMUS_MODEL": "mixtral_8x7B_v0.1",
+                "PRIMUS_GLOBAL_BATCH_SIZE": "8",
                 "PRIMUS_EP": "8",
                 "PRIMUS_NUM_LAYERS": "4",
             },
@@ -75,7 +82,6 @@ class TestMegatronTrainer(PrimusUT):
         self._run_script(
             "deepseek_v3",
             env_override={
-                "BACKEND": "megatron",
                 "PRIMUS_MODEL": "deepseek_v3",
                 "PRIMUS_GLOBAL_BATCH_SIZE": "8",
                 "PRIMUS_MOE_LAYER_FREQ": "[0]*3+[1]*1",
@@ -88,7 +94,6 @@ class TestMegatronTrainer(PrimusUT):
         self._run_script(
             "interleaved_pipeline_parallelism",
             env_override={
-                "BACKEND": "megatron",
                 "PRIMUS_MODEL": "deepseek_v2_lite",
                 "PRIMUS_GLOBAL_BATCH_SIZE": "16",
                 "PRIMUS_MOE_LAYER_FREQ": "[0]*1+[1]*7",

--- a/tests/trainer/test_megatron_trainer.yaml
+++ b/tests/trainer/test_megatron_trainer.yaml
@@ -52,7 +52,8 @@ modules:
 
       # data
       num_workers: 1
-      train_data_path: ${TOKENIZED_DATA_PATH:null}
+      mock_data: true
+      train_data_path: null
       valid_data_path: null
       test_data_path: null
 


### PR DESCRIPTION
## Description

This PR includes the following changes:

### ✅ Test Enhancements
- Added  new unit test for `mixtral_8x22B_v0.1` 、mixtral_8x7B_v0.1, including:
  - `PRIMUS_MOE_LAYER_FREQ` and `PRIMUS_NUM_LAYERS` setup.
  - Basic validation using the `PrimusUT` framework.

### 🛠 Script Improvement
- Updated `examples/run_pretrain.sh` to support an optional `TRAIN_LOG` override:
  ```bash
  TRAIN_LOG=${TRAIN_LOG:-"output/log_torchrun_pretrain_$(basename "$EXP" .yaml).txt"}