### PR TITLE
fix(trainer): auto-enable tensorboard when profiling is enabled

### DIFF
--- a/primus/modules/trainer/megatron/trainer.py
+++ b/primus/modules/trainer/megatron/trainer.py
@@ -742,6 +742,10 @@ class MegatronTrainer(BaseTrainer, BaseModule):
         else:
             os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "8"
 
+        # profile
+        if args.profile:
+            args.disable_tensorboard = False
+
         # checkpoint
         ckpt_path = os.path.abspath(os.path.join(exp_root_path, "checkpoints"))
         if args.save is not None:


### PR DESCRIPTION
When --profile is enabled in MegatronTrainer, this change ensures that
TensorBoard logging is automatically turned on (i.e., disable_tensorboard=False),
so profiler data can be tracked correctly.

This avoids confusion where profiling runs produce no TensorBoard output due to
disable_tensorboard being True by default.