### PR TITLE
 feat: Unify config/backend CLI & add config export support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
-[submodule "third_party/Megatron-LM"]
-	path = third_party/megatron
-	url = https://github.com/NVIDIA/Megatron-LM.git
-	branch = main
 [submodule "third_party/torchtitan"]
 	path = third_party/torchtitan
 	url = https://github.com/pytorch/torchtitan.git
+[submodule "third_party/Megatron-LM"]
+	path = third_party/Megatron-LM
+	url = https://github.com/NVIDIA/Megatron-LM.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "third_party/Megatron-LM"]
-	path = third_party/Megatron-LM
+	path = third_party/megatron
 	url = https://github.com/NVIDIA/Megatron-LM.git
 	branch = main
 [submodule "third_party/torchtitan"]

--- a/examples/megatron/configs/deepseek_v2_lite-pretrain.yaml
+++ b/examples/megatron/configs/deepseek_v2_lite-pretrain.yaml
@@ -62,7 +62,7 @@ modules:
       moe_use_fused_router_with_aux_score: false
       # pad 192/128 for deepseek attention
       fused_padded_mla_attention: false
-      
+
       multi_latent_attention: false
 
       # ckpt

--- a/examples/megatron/configs/llama3.3_70B-pretrain.yaml
+++ b/examples/megatron/configs/llama3.3_70B-pretrain.yaml
@@ -22,7 +22,7 @@ modules:
 
       seq_length: 8192
       max_position_embeddings: 8192
-      
+
       lr: 1.0e-5
       min_lr: 0.0
       lr_warmup_iters: 2

--- a/examples/megatron/configs/qwen2.5_72B-pretrain.yaml
+++ b/examples/megatron/configs/qwen2.5_72B-pretrain.yaml
@@ -30,7 +30,7 @@ modules:
       lr: 1.0e-4
       min_lr: 1.0e-5
       lr_warmup_iters: 2
-      lr_decay_iters: 320000 
+      lr_decay_iters: 320000
       lr_decay_style: cosine
       weight_decay: 1.0e-1
       adam_beta1: 0.9
@@ -45,7 +45,7 @@ modules:
       expert_model_parallel_size: 1
       sequence_parallel: 1
       overlap_grad_reduce: true
-      
+
       overlap_param_gather: false
       use_torch_fsdp2: true
       use_distributed_optimizer: false

--- a/examples/megatron/configs/qwen2.5_7B-pretrain.yaml
+++ b/examples/megatron/configs/qwen2.5_7B-pretrain.yaml
@@ -31,7 +31,7 @@ modules:
       lr: 1.0e-5
       min_lr: 0.0
       lr_warmup_iters: 2
-      lr_decay_iters: 320000 
+      lr_decay_iters: 320000
       lr_decay_style: cosine
       weight_decay: 0.1
       adam_beta1: 0.9

--- a/examples/megatron/prepare.py
+++ b/examples/megatron/prepare.py
@@ -133,23 +133,24 @@ def prepare_dataset_if_needed(
     write_patch_args(Path(patch_args), "train_args", {"train_data_path": str(tokenized_data_path)})
 
 
-def build_megatron_helper(primus_path: Path):
+def build_megatron_helper(primus_path: Path, patch_args: Path, backend_path: str = None):
     """Build Megatron's helper C++ dataset library."""
-    megatron_env = get_env_case_insensitive("MEGATRON_PATH")
-    if megatron_env:
-        megatron_path = Path(megatron_env).resolve()
-        log_info(f"MEGATRON_PATH found in environment: {megatron_path}")
+    if backend_path:
+        megatron_path = Path(backend_path).resolve()
+        log_info(f"Using backend_path from argument: {megatron_path}")
     else:
-        megatron_path = primus_path / "third_party/Megatron-LM"
-        log_info(f"MEGATRON_PATH not found, falling back to: {megatron_path}")
+        # megatron_path = primus_path / "third_party/megatron"
+        # log_info(f"No backend_path provided, falling back to: {megatron_path}")
+        env_backend = get_env_case_insensitive("MEGATRON_PATH")
+        if env_backend:
+            megatron_path = Path(env_backend).resolve()
+            log_info(f"Using backend_path from environment: {megatron_path}")
+        else:
+            megatron_path = primus_path / "third_party/megatron"
+            log_info(f"No backend_path provided, falling back to: {megatron_path}")
+    write_patch_args(Path(patch_args), "train_args", {"backend_path": str(megatron_path)})
 
     check_dir_nonempty(megatron_path, "megatron")
-
-    # pip install -e .
-    log_info(f"Installing Megatron in editable mode via pip (path: {megatron_path})")
-    ret = subprocess.run(["pip", "install", "-e", ".", "-q"], cwd=megatron_path)
-    if ret.returncode != 0:
-        log_error_and_exit("Failed to install Megatron via pip.")
 
     # build C++ helper
     dataset_cpp_dir = megatron_path / "megatron/core/datasets"
@@ -165,15 +166,22 @@ def main():
     parser = argparse.ArgumentParser(description="Prepare Primus environment")
     parser.add_argument("--primus_path", type=str, required=True, help="Root path to the Primus project")
     parser.add_argument("--data_path", type=str, required=True, help="Path to data directory")
-    parser.add_argument("--exp", type=str, required=True, help="Path to experiment YAML config")
+    parser.add_argument("--config", type=str, required=True, help="Path to experiment YAML config")
     parser.add_argument(
         "--patch_args",
         type=str,
         default="/tmp/primus_patch_args.txt",
         help="Path to write additional args (used during training phase)",
     )
+    parser.add_argument(
+        "--backend_path",
+        type=str,
+        default=None,
+        help="Optional path to backend (e.g., Megatron), will be added to PYTHONPATH",
+    )
     args = parser.parse_args()
 
+    log_info(f"BACKEND_PATH {args.backend_path}")
     primus_config = PrimusParser().parse(args)
 
     primus_path = Path(args.primus_path).resolve()
@@ -182,7 +190,7 @@ def main():
     data_path = Path(args.data_path).resolve()
     log_info(f"DATA_PATH is set to: {data_path}")
 
-    exp_path = Path(args.exp).resolve()
+    exp_path = Path(args.config).resolve()
     if not exp_path.is_file():
         log_error_and_exit(f"The specified EXP file does not exist: {exp_path}")
     log_info(f"EXP is set to: {exp_path}")
@@ -201,7 +209,7 @@ def main():
             patch_args=patch_args_file,
         )
 
-    build_megatron_helper(primus_path=primus_path)
+    build_megatron_helper(primus_path=primus_path, backend_path=args.backend_path, patch_args=patch_args_file)
 
 
 if __name__ == "__main__":

--- a/examples/megatron/prepare.py
+++ b/examples/megatron/prepare.py
@@ -146,7 +146,7 @@ def build_megatron_helper(primus_path: Path, patch_args: Path, backend_path: str
             megatron_path = Path(env_backend).resolve()
             log_info(f"Using backend_path from environment: {megatron_path}")
         else:
-            megatron_path = primus_path / "third_party/megatron"
+            megatron_path = primus_path / "third_party/Megatron-LM"
             log_info(f"No backend_path provided, falling back to: {megatron_path}")
     write_patch_args(Path(patch_args), "train_args", {"backend_path": str(megatron_path)})
 

--- a/examples/run_local_pretrain.sh
+++ b/examples/run_local_pretrain.sh
@@ -90,21 +90,21 @@ fi
 
 # ------------------ Launch Training Container ------------------
 bash "${PRIMUS_PATH}"/tools/docker/docker_podman_proxy.sh run --rm \
-    --env MASTER_ADDR="${MASTER_ADDR}" \
-    --env MASTER_PORT="${MASTER_PORT}" \
-    --env NNODES="${NNODES}" \
-    --env NODE_RANK="${NODE_RANK}" \
-    --env GPUS_PER_NODE="${GPUS_PER_NODE}" \
-    --env DATA_PATH="${DATA_PATH}" \
-    --env TRAIN_LOG="${TRAIN_LOG}" \
-    --env HSA_NO_SCRATCH_RECLAIM="${HSA_NO_SCRATCH_RECLAIM}" \
-    --env NVTE_CK_USES_BWD_V3="${NVTE_CK_USES_BWD_V3}" \
-    --env NCCL_IB_HCA="${NCCL_IB_HCA}" \
-    --env GPU_MAX_HW_QUEUES="${GPU_MAX_HW_QUEUES}" \
-    --env GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME}" \
-    --env NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME}" \
-    --env REBUILD_BNXT="${REBUILD_BNXT}" \
-    --env PATH_TO_BNXT_TAR_PACKAGE="${PATH_TO_BNXT_TAR_PACKAGE}" \
+    --env MASTER_ADDR \
+    --env MASTER_PORT \
+    --env NNODES \
+    --env NODE_RANK \
+    --env GPUS_PER_NODE \
+    --env DATA_PATH \
+    --env TRAIN_LOG \
+    --env HSA_NO_SCRATCH_RECLAIM \
+    --env NVTE_CK_USES_BWD_V3 \
+    --env NCCL_IB_HCA \
+    --env GPU_MAX_HW_QUEUES \
+    --env GLOO_SOCKET_IFNAME \
+    --env NCCL_SOCKET_IFNAME \
+    --env REBUILD_BNXT \
+    --env PATH_TO_BNXT_TAR_PACKAGE \
     --env MEGATRON_PATH \
     --env TORCHTITAN_PATH \
     --env BACKEND_PATH \

--- a/examples/run_local_pretrain.sh
+++ b/examples/run_local_pretrain.sh
@@ -105,6 +105,10 @@ bash "${PRIMUS_PATH}"/tools/docker/docker_podman_proxy.sh run --rm \
     --env NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME}" \
     --env REBUILD_BNXT="${REBUILD_BNXT}" \
     --env PATH_TO_BNXT_TAR_PACKAGE="${PATH_TO_BNXT_TAR_PACKAGE}" \
+    --env MEGATRON_PATH \
+    --env TORCHTITAN_PATH \
+    --env BACKEND_PATH \
+    --env HF_TOKEN \
     "${ENV_ARGS[@]}" \
     --ipc=host --network=host \
     --device=/dev/kfd --device=/dev/dri \

--- a/examples/run_pretrain.sh
+++ b/examples/run_pretrain.sh
@@ -305,86 +305,38 @@ handle_hipblaslt_tuning() {
 handle_hipblaslt_tuning
 
 # -------------------- Python Path Setup --------------------
-
-check_dir_nonempty() {
-    local dir_path=$1
-    local name=$2
-    if [[ ! -d "$dir_path" || -z "$(ls -A "$dir_path")" ]]; then
-        echo "[ERROR] $name ($dir_path) does not exist or is empty."
-        echo "        Please ensure Primus is properly initialized."
-        echo
-        echo "        If not yet cloned, run:"
-        echo "            git clone --recurse-submodules git@github.com:AMD-AIG-AIMA/Primus.git"
-        echo
-        echo "        Or if already cloned, initialize submodules with:"
-        echo "            git submodule update --init --recursive"
-        echo
-        exit 1
-    fi
-}
-
-
 setup_pythonpath() {
-    # Get site-packages directory for current Python environment
     local site_packages
     site_packages=$(python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")
-
-    local third_party_path="${PRIMUS_PATH}/third_party"
-    local third_party_pythonpath=""
-
-    # Define backend names that can be overridden via environment variables
-    local CUSTOM_BACKENDS=("megatron" "torchtitan")
-    declare -A CUSTOM_BACKEND_PATHS
-
-    # Load backend paths from environment variables (e.g., MEGATRON_PATH)
-    for backend in "${CUSTOM_BACKENDS[@]}"; do
-        # Convert backend name to uppercase and append _PATH (e.g., MEGATRON_PATH)
-        env_var_name="$(echo "${backend}_path" | tr '[:lower:]' '[:upper:]')"
-        backend_path="${!env_var_name}"
-        if [[ -n "$backend_path" ]]; then
-            check_dir_nonempty "$env_var_name" "$backend_path"
-            CUSTOM_BACKEND_PATHS["$backend"]="$backend_path"
-        fi
-    done
-
-    declare -A DIR_TO_BACKEND=(
-        ["Megatron-LM"]="megatron"
-        ["torchtitan"]="torchtitan"
-    )
-    # Collect third_party paths, excluding overridden backends
-    while IFS= read -r dir; do
-        base_name=$(basename "$dir")
-        base_name="${DIR_TO_BACKEND[$base_name]}"
-        if [[ -n "${CUSTOM_BACKEND_PATHS[$base_name]}" ]]; then
-            continue
-        fi
-        third_party_pythonpath+="${dir}:"
-    done < <(find "${third_party_path}" -mindepth 1 -maxdepth 1 -type d -exec realpath {} \;)
-
-    third_party_pythonpath="${third_party_pythonpath%:}"  # Remove trailing colon
-
-    # Start building final PYTHONPATH
-    local full_pythonpath="${site_packages}:${PRIMUS_PATH}:${third_party_pythonpath}"
-
-    # Prepend custom backend paths if defined
-    for backend in "${CUSTOM_BACKENDS[@]}"; do
-        custom_path="${CUSTOM_BACKEND_PATHS[$backend]}"
-        [[ -n "$custom_path" ]] && full_pythonpath="${custom_path}:${full_pythonpath}"
-    done
-
-    export PYTHONPATH="${full_pythonpath}:${PYTHONPATH}"
+    export PYTHONPATH="${site_packages}:${PRIMUS_PATH}:$:${PYTHONPATH}"
 }
 
 setup_pythonpath
 
-PRIMUS_PATCH_ARGS_FILE=$(mktemp /tmp/primus_patch_args.XXXXXX.yaml)
-trap 'rm -f "$PRIMUS_PATCH_ARGS_FILE"' EXIT
+run_prepare_experiment() {
+    PRIMUS_PATCH_ARGS_FILE=$(mktemp /tmp/primus_patch_args.XXXXXX.yaml)
+    trap 'rm -f "$PRIMUS_PATCH_ARGS_FILE"' EXIT
 
-SCRIPT="$PRIMUS_PATH/examples/scripts/prepare_experiment.py"
-if ! python3 "$SCRIPT" --exp "$EXP" --data_path "$DATA_PATH" --patch_args "$PRIMUS_PATCH_ARGS_FILE"; then
-    LOG_ERROR "$SCRIPT failed, aborting."
-    exit 1
-fi
+    SCRIPT="$PRIMUS_PATH/examples/scripts/prepare_experiment.py"
+
+    # Conditionally construct the --backend_path argument if BACKEND_PATH is set
+    BACKEND_ARG=()
+    if [[ -n "${BACKEND_PATH}" ]]; then
+        BACKEND_ARG=(--backend_path "$BACKEND_PATH")
+    fi
+
+    # Run the prepare_experiment.py script with required and optional arguments
+    if ! python3 "$SCRIPT" \
+        --config "$EXP" \
+        --data_path "$DATA_PATH" \
+        --patch_args "$PRIMUS_PATCH_ARGS_FILE" \
+        "${BACKEND_ARG[@]}"; then
+        LOG_ERROR "$SCRIPT failed, aborting."
+        exit 1
+    fi
+}
+
+run_prepare_experiment
 
 # ---------- Parse optional patch args ----------
 TRAIN_EXTRA_ARGS=""

--- a/examples/scripts/prepare_experiment.py
+++ b/examples/scripts/prepare_experiment.py
@@ -24,13 +24,19 @@ def log(msg, level="INFO"):
 
 def main():
     parser = argparse.ArgumentParser(description="Primus Backend Preparation Entry")
-    parser.add_argument("--exp", required=True, help="Path to experiment YAML config file")
+    parser.add_argument("--config", required=True, help="Path to experiment YAML config file")
     parser.add_argument("--data_path", required=True, help="Root directory for datasets and tokenizer")
     parser.add_argument(
         "--patch_args",
         type=str,
         default="/tmp/primus_patch_args.txt",
         help="Path to write additional args (used during training phase)",
+    )
+    parser.add_argument(
+        "--backend_path",
+        type=str,
+        default=None,
+        help="Optional path to backend (e.g., Megatron), will be added to PYTHONPATH",
     )
     args = parser.parse_args()
 
@@ -40,26 +46,38 @@ def main():
 
     config = PrimusParser().parse(args)
     framework = config.get_module_config("pre_trainer").framework
-    script = primus_path / "examples" / framework / "prepare.py"
+    framework_map = {
+        "megatron": "megatron",
+        "torchtitan": "torchtitan",
+        # Add more aliases here if needed
+    }
+    framework_dir = framework_map.get(framework, framework)
+
+    # Construct the script path
+    script = Path(primus_path) / "examples" / framework_dir / "prepare.py"
 
     if not script.exists():
         log_info(f"Backend prepare script not found: {script}")
 
     log_info(f"Running backend prepare: {script}")
+    cmd = [
+        "python",
+        str(script),
+        "--config",
+        args.config,
+        "--data_path",
+        args.data_path,
+        "--primus_path",
+        str(primus_path),
+        "--patch_args",
+        str(patch_args_path),
+    ]
+
+    if args.backend_path:
+        cmd += ["--backend_path", args.backend_path]
     try:
         subprocess.run(
-            [
-                "python",
-                str(script),
-                "--exp",
-                args.exp,
-                "--data_path",
-                args.data_path,
-                "--primus_path",
-                primus_path,
-                "--patch_args",
-                str(patch_args_path),
-            ],
+            cmd,
             check=True,
             text=True,
             stdout=sys.stdout,

--- a/examples/torchtitan/prepare.py
+++ b/examples/torchtitan/prepare.py
@@ -46,12 +46,18 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Prepare Primus environment")
     parser.add_argument("--primus_path", type=str, required=True, help="Root path to the Primus project")
     parser.add_argument("--data_path", type=str, required=True, help="Path to data directory")
-    parser.add_argument("--exp", type=str, required=True, help="Path to experiment YAML config")
+    parser.add_argument("--config", type=str, required=True, help="Path to experiment YAML config")
     parser.add_argument(
         "--patch_args",
         type=str,
         default="/tmp/primus_patch_args.txt",
         help="Path to write additional args (used during training phase)",
+    )
+    parser.add_argument(
+        "--backend_path",
+        type=str,
+        default=None,
+        help="Optional override for TorchTitan path; takes precedence over env and default.",
     )
     return parser.parse_args()
 
@@ -63,14 +69,20 @@ def pip_install_editable(path: Path, name: str):
         log_error_and_exit(f"Failed to install {name} via pip.")
 
 
-def resolve_backend_path(env_var: str, default_subdir: str, primus_path: Path, name: str) -> Path:
-    env_value = get_env_case_insensitive(env_var)
-    if env_value:
-        path = Path(env_value).resolve()
-        log_info(f"{env_var.upper()} found in environment: {path}")
+def resolve_backend_path(
+    cli_path: Optional[str], env_var: str, default_subdir: str, primus_path: Path, name: str
+) -> Path:
+    if cli_path:
+        path = Path(cli_path).resolve()
+        log_info(f"Using {name} path from CLI: {path}")
     else:
-        path = primus_path / default_subdir
-        log_info(f"{env_var.upper()} not found, falling back to: {path}")
+        env_value = get_env_case_insensitive(env_var)
+        if env_value:
+            path = Path(env_value).resolve()
+            log_info(f"{env_var.upper()} found in environment: {path}")
+        else:
+            path = primus_path / default_subdir
+            log_info(f"{env_var.upper()} not found, falling back to: {path}")
     return path
 
 
@@ -79,13 +91,14 @@ def main():
 
     primus_path = Path(args.primus_path).resolve()
     data_path = Path(args.data_path).resolve()
-    exp_path = Path(args.exp).resolve()
+    exp_path = Path(args.config).resolve()
     patch_args_file = Path(args.patch_args).resolve()
 
     log_info(f"PRIMUS_PATH: {primus_path}")
-    log_info(f"DATA_PATH  : {data_path}")
-    log_info(f"EXP        : {exp_path}")
-    log_info(f"PATCH-ARGS : {patch_args_file}")
+    log_info(f"DATA_PATH: {data_path}")
+    log_info(f"EXP: {exp_path}")
+    log_info(f"BACKEND_PATH: {args.backend_path}")
+    log_info(f"PATCH-ARGS: {patch_args_file}")
 
     if not exp_path.is_file():
         log_error_and_exit(f"EXP file not found: {exp_path}")
@@ -93,7 +106,7 @@ def main():
     primus_cfg = PrimusParser().parse(args)
 
     torchtitan_path = resolve_backend_path(
-        "TORCHTITAN_PATH", "third_party/torchtitan", primus_path, "torchtitan"
+        args.backend_path, "TORCHTITAN_PATH", "third_party/torchtitan", primus_path, "TorchTitan"
     )
     pip_install_editable(torchtitan_path, "TorchTitan")
 
@@ -131,7 +144,8 @@ def main():
     else:
         log_info(f"Tokenizer file exists: {tokenizer_file}")
     write_patch_args(patch_args_file, "train_args", {"model.tokenizer_path": str(tokenizer_file)})
-    write_patch_args(patch_args_file, "torchrun_args", {"local-ranks-filter": "0"})
+    write_patch_args(patch_args_file, "train_args", {"backend_path": str(torchtitan_path)})
+    write_patch_args(patch_args_file, "torchrun_args", {"local-ranks-filter": "1"})
 
 
 if __name__ == "__main__":

--- a/primus/configs/models/megatron/qwen2.5_72B.yaml
+++ b/primus/configs/models/megatron/qwen2.5_72B.yaml
@@ -9,4 +9,4 @@ hidden_size: 8192
 ffn_hidden_size: 29568
 num_layers: 80
 num_attention_heads: 64
-num_query_groups: 8 
+num_query_groups: 8

--- a/primus/configs/models/megatron/qwen2.5_7B.yaml
+++ b/primus/configs/models/megatron/qwen2.5_7B.yaml
@@ -9,4 +9,4 @@ hidden_size: 3584
 ffn_hidden_size: 18944
 num_layers: 28
 num_attention_heads: 28
-num_query_groups: 4 
+num_query_groups: 4

--- a/primus/configs/models/megatron/qwen2.5_base.yaml
+++ b/primus/configs/models/megatron/qwen2.5_base.yaml
@@ -24,4 +24,4 @@ norm_epsilon: 1.0e-6
 init_method_std: 0.008
 
 apply_rope_fusion: true
-masked_softmax_fusion: false 
+masked_softmax_fusion: false

--- a/primus/core/launcher/parser.py
+++ b/primus/core/launcher/parser.py
@@ -7,6 +7,7 @@ from typing import List
 from primus.core.launcher.config import PrimusConfig
 from primus.core.utils import constant_vars, yaml_utils
 
+
 def add_pretrain_parser(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--config",
@@ -29,6 +30,7 @@ def add_pretrain_parser(parser: argparse.ArgumentParser):
         help="Optional path to export the final merged config to a file.",
     )
     return parser
+
 
 def _parse_args(extra_args_provider=None, ignore_unknown_args=False) -> tuple[argparse.Namespace, List[str]]:
     parser = argparse.ArgumentParser(description="Primus Arguments", allow_abbrev=False)
@@ -146,6 +148,7 @@ def parse_args(extra_args_provider=None, ignore_unknown_args=False):
     _deep_merge_namespace(pre_trainer_cfg, overrides)
 
     return primus_config
+
 
 def load_primus_config(args: argparse.Namespace, overrides: List[str]) -> PrimusConfig:
     """

--- a/primus/core/launcher/parser.py
+++ b/primus/core/launcher/parser.py
@@ -7,6 +7,28 @@ from typing import List
 from primus.core.launcher.config import PrimusConfig
 from primus.core.utils import constant_vars, yaml_utils
 
+def add_pretrain_parser(parser: argparse.ArgumentParser):
+    parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        help="Path to experiment YAML config file (alias: --exp)",
+    )
+    parser.add_argument(
+        "--backend_path",
+        nargs="?",
+        default=None,
+        help=(
+            "Optional backend import path for Megatron or TorchTitan. "
+            "If provided, it will be appended to PYTHONPATH dynamically."
+        ),
+    )
+    parser.add_argument(
+        "--export_config",
+        type=str,
+        help="Optional path to export the final merged config to a file.",
+    )
+    return parser
 
 def _parse_args(extra_args_provider=None, ignore_unknown_args=False) -> tuple[argparse.Namespace, List[str]]:
     parser = argparse.ArgumentParser(description="Primus Arguments", allow_abbrev=False)
@@ -19,9 +41,17 @@ def _parse_args(extra_args_provider=None, ignore_unknown_args=False) -> tuple[ar
         required=True,
         help="Path to experiment YAML config file (alias: --exp)",
     )
-
     parser.add_argument(
-        "--export-config",
+        "--backend_path",
+        nargs="?",
+        default=None,
+        help=(
+            "Optional backend import path for Megatron or TorchTitan. "
+            "If provided, it will be appended to PYTHONPATH dynamically."
+        ),
+    )
+    parser.add_argument(
+        "--export_config",
         type=str,
         help="Optional path to export the final merged config to a file.",
     )
@@ -115,10 +145,31 @@ def parse_args(extra_args_provider=None, ignore_unknown_args=False):
     _check_keys_exist(pre_trainer_cfg, overrides)
     _deep_merge_namespace(pre_trainer_cfg, overrides)
 
-    if args.export_config:
-        from primus.core.utils.yaml_utils import dump_namespace_to_yaml
+    return primus_config
 
-        dump_namespace_to_yaml(primus_config.exp, args.export_config)
+def load_primus_config(args: argparse.Namespace, overrides: List[str]) -> PrimusConfig:
+    """
+    Build the Primus configuration with optional command-line overrides.
+
+    Args:
+        args: Parsed CLI arguments.
+        overrides: Key-value pairs from CLI for overriding configs, e.g.:
+                   ["training.steps", "1000", "optimizer.lr", "0.001"]
+
+    Returns:
+        The merged Primus configuration namespace.
+    """
+    # 1 Parse the base config from args
+    config_parser = PrimusParser()
+    primus_config = config_parser.parse(args)
+
+    # 2 Parse overrides from flat list to dict/namespace
+    override_ns = _parse_kv_overrides(overrides)
+
+    # 3 Apply overrides to pre_trainer module config
+    pre_trainer_cfg = primus_config.get_module_config("pre_trainer")
+    _check_keys_exist(pre_trainer_cfg, override_ns)
+    _deep_merge_namespace(pre_trainer_cfg, override_ns)
 
     return primus_config
 
@@ -128,7 +179,7 @@ class PrimusParser(object):
         pass
 
     def parse(self, cli_args: argparse.Namespace) -> PrimusConfig:
-        exp_yaml_cfg = cli_args.exp
+        exp_yaml_cfg = cli_args.config
         self.primus_home = Path(os.path.dirname(__file__)).parent.parent.absolute()
         self.parse_exp(exp_yaml_cfg)
         self.parse_meta_info()
@@ -157,6 +208,7 @@ class PrimusParser(object):
         # Load platform config
         config_path = os.path.join(self.primus_home, "configs/platforms", self.exp.platform.config)
         platform_config = yaml_utils.parse_yaml_to_namespace(config_path)
+        platform_config.config = self.exp.platform.config
 
         # Optional overrides
         if yaml_utils.has_key_in_namespace(self.exp.platform, "overrides"):
@@ -182,35 +234,44 @@ class PrimusParser(object):
         assert framework in map, f"Invalid module framework: {framework}."
         return map[framework]
 
-    def parse_trainer_module(self, module_name):
+    def parse_trainer_module(self, module_name: str):
         module = yaml_utils.get_value_by_key(self.exp.modules, module_name)
         module.name = f"exp.modules.{module_name}"
+
+        # Ensure framework exists
         yaml_utils.check_key_in_namespace(module, "framework")
-        yaml_utils.check_key_in_namespace(module, "config")
-        yaml_utils.check_key_in_namespace(module, "model")
         framework = module.framework
 
-        # config
+        # If both config and model are missing, skip
+        has_config = yaml_utils.has_key_in_namespace(module, "config")
+        has_model = yaml_utils.has_key_in_namespace(module, "model")
+        if not has_config and not has_model:
+            return
+
+        # Validate required keys
+        for key in ("config", "model"):
+            yaml_utils.check_key_in_namespace(module, key)
+
+        # ---- Load module config ----
         module_config_file = os.path.join(self.primus_home, "configs/modules", framework, module.config)
         module_config = yaml_utils.parse_yaml_to_namespace(module_config_file)
         module_config.name = f"exp.modules.{module_name}.config"
-
-        # framework
         module_config.framework = framework
 
-        # model
+        # ---- Load model config ----
         model_format = self.get_model_format(framework)
         model_config_file = os.path.join(self.primus_home, "configs/models", model_format, module.model)
         model_config = yaml_utils.parse_yaml_to_namespace(model_config_file)
         model_config.name = f"exp.modules.{module_name}.model"
 
-        # module config = config + model + overrides
+        # ---- Merge: config + model ----
         yaml_utils.merge_namespace(module_config, model_config, allow_override=False, excepts=["name"])
 
+        # ---- Apply overrides if present ----
         if yaml_utils.has_key_in_namespace(module, "overrides"):
             yaml_utils.override_namespace(module_config, module.overrides)
 
-        # flatten args of exp.modules.module_name
+        # ---- Flatten and save back ----
         module_config.name = module_name
         yaml_utils.set_value_by_key(self.exp.modules, module_name, module_config, allow_override=True)
 
@@ -221,3 +282,14 @@ class PrimusParser(object):
                 self.parse_trainer_module(module_name)
             else:
                 raise ValueError(f"Unsupported module: {module_name}")
+
+    def export(self, export_path):
+        """
+        Export the merged Primus config (exp) to YAML.
+        """
+        path = Path(export_path).resolve()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = yaml_utils.nested_namespace_to_dict(self.exp)
+        yaml_utils.dump_namespace_to_yaml(data, str(path))
+        print(f"[PrimusConfig] Exported merged config to {path}")
+        return path

--- a/primus/train.py
+++ b/primus/train.py
@@ -4,9 +4,13 @@
 # See LICENSE for license information.
 ###############################################################################
 
+import argparse
 import os
+import sys
+from pathlib import Path
 
-from primus.core.launcher.parser import parse_args
+from primus.core.launcher.config import PrimusConfig
+from primus.core.launcher.parser import add_pretrain_parser, load_primus_config
 
 
 # Lazy backend loader
@@ -25,19 +29,78 @@ def load_backend_trainer(framework: str):
         raise ValueError(f"Unsupported framework: {framework}")
 
 
-if __name__ == "__main__":
-    primus_cfg = parse_args()
+def setup_backend_path(framework: str, backend_path=None, verbose: bool = True):
+    """
+    Setup Python path for backend modules.
+
+    Priority order:
+    1. --backend-path from CLI
+    2. BACKEND_PATH from environment
+    3. Source tree fallback: <primus>/../../third_party/{framework}
+
+    Returns:
+        str: The first valid backend path inserted into sys.path.
+    """
+    candidate_paths = []
+
+    # 1) From CLI
+    if backend_path:
+        if isinstance(backend_path, str):
+            backend_path = [backend_path]
+        candidate_paths.extend(backend_path)
+
+    # 2) From environment variable
+    env_path = os.getenv("BACKEND_PATH")
+    if env_path:
+        candidate_paths.append(env_path)
+
+    # 3) Fallback to source tree under third_party
+    default_path = Path(__file__).resolve().parent.parent / "third_party" / framework
+    candidate_paths.append(default_path)
+
+    # Normalize & deduplicate
+    candidate_paths = list(dict.fromkeys(os.path.normpath(os.path.abspath(p)) for p in candidate_paths))
+
+    # Insert the first existing path into sys.path
+    for path in candidate_paths:
+        if os.path.exists(path):
+            if path not in sys.path:
+                sys.path.insert(0, path)
+                if verbose:
+                    print(f"[Primus] sys.path.insert: {path}")
+            return path  # Return the first valid path
+
+    # None of the candidate paths exist
+    raise FileNotFoundError(
+        f"[Primus] backend_path not found for framework '{framework}'. " f"Tried paths: {candidate_paths}"
+    )
+
+
+def launch_pretrain_trainer(primus_cfg: PrimusConfig):
+    """
+    Launch the training using the Primus trainer.
+
+    Args:
+        primus_cfg (PrimusConfig): Parsed Primus configuration object.
+    """
+    # Get pre_trainer module configuration
+    pre_trainer_cfg = primus_cfg.get_module_config("pre_trainer")
+    framework = pre_trainer_cfg.framework
+
+    # Setup backend path for dynamic import
+    framework = primus_cfg.get_module_config("pre_trainer").framework
+    setup_backend_path(framework=framework, backend_path=args.backend_path, verbose=True)
+
+    # Lazy import backend trainer
+    TrainerClass = load_backend_trainer(framework)
 
     # envs set by torchrun
     rank = int(os.getenv("RANK", "0"))
     world_size = int(os.getenv("WORLD_SIZE", "1"))
-    master_addr = os.getenv("MASTER_ADDR")
-    master_port = int(os.getenv("MASTER_PORT"))
+    master_addr = os.getenv("MASTER_ADDR", "127.0.0.1")
+    master_port = int(os.getenv("MASTER_PORT", "29500"))
 
-    pre_trainer_cfg = primus_cfg.get_module_config("pre_trainer")
-
-    TrainerClass = load_backend_trainer(pre_trainer_cfg.framework)
-
+    # Initialize trainer
     trainer = TrainerClass(
         module_name="pre_trainer",
         primus_config=primus_cfg,
@@ -47,5 +110,43 @@ if __name__ == "__main__":
         module_master_port=master_port,
     )
 
+    # Launch training
     trainer.init()
     trainer.run()
+
+
+def launch_pretrain_from_cli(args, overrides):
+    """
+    Entry point for the 'train' subcommand.
+
+     Steps:
+        1. Load and parse the experiment YAML config
+        2. Merge CLI overrides into the config
+        3. Optionally export the merged config
+        4. Setup backend path
+        5. Launch the training
+    """
+    cfg_path = Path(args.config)
+    if not cfg_path.exists():
+        raise FileNotFoundError(f"[Primus:Train] Config file '{cfg_path}' not found.")
+
+    primus_cfg = load_primus_config(args, overrides)
+
+    # Export merged config if requested
+    if args.export_config:
+        primus_cfg.export(export_path=args.export_config)
+
+    # Setup backend path for dynamic import
+    framework = primus_cfg.get_module_config("pre_trainer").framework
+    setup_backend_path(framework=framework, backend_path=args.backend_path, verbose=True)
+
+    launch_pretrain_trainer(primus_cfg=primus_cfg)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="pretrain")
+    add_pretrain_parser(parser)
+
+    args, unknown_args = parser.parse_known_args()
+
+    launch_pretrain_from_cli(args, unknown_args)

--- a/primus/train.py
+++ b/primus/train.py
@@ -55,7 +55,12 @@ def setup_backend_path(framework: str, backend_path=None, verbose: bool = True):
         candidate_paths.append(env_path)
 
     # 3) Fallback to source tree under third_party
-    default_path = Path(__file__).resolve().parent.parent / "third_party" / framework
+    fallback_name_map = {
+        "megatron": "Megatron-LM",
+        "torchtitan": "torchtitan",
+    }
+    mapped_name = fallback_name_map.get(framework, framework)
+    default_path = Path(__file__).resolve().parent.parent / "third_party" / mapped_name
     candidate_paths.append(default_path)
 
     # Normalize & deduplicate

--- a/tests/configs/test_config.py
+++ b/tests/configs/test_config.py
@@ -40,7 +40,7 @@ class TestPrimusParser(PrimusUT):
         ]
 
         for exp in exps:
-            self.cli_args.exp = exp
+            self.cli_args.config = exp
             logger.info(f"test exp config: {exp}")
             logger.debug(f"============================")
             exp_config = self.parse_config(self.cli_args)
@@ -80,6 +80,37 @@ class TestPrimusParser(PrimusUT):
         self.assertEqual(ns.a, 10)
         self.assertEqual(ns.b.c, 20)
         self.assertEqual(ns.flag, True)
+
+    def test_export_and_parse_cycle_with_real_yaml(self):
+        """
+        Test that a config exported by PrimusConfig.export from a real YAML
+        can be parsed back by PrimusParser.parse without loss or error.
+        """
+        import tempfile, os
+        from primus.core.launcher.config import PrimusConfig
+
+        # Step 1: Load original config using parser
+        original_args = argparse.Namespace(config="examples/megatron/exp_pretrain.yaml")
+        original_cfg = self.config_parser.parse(original_args)
+
+        # Step 2: Export to temp file
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = os.path.join(tmpdir, "exported_config.yaml")
+            self.config_parser.export(out_path)
+
+            # Step 3: Parse the exported config
+            reload_args = argparse.Namespace(config=out_path)
+            reloaded_cfg = self.config_parser.parse(reload_args)
+
+            # Step 4: Assert that some key fields match (e.g. model, modules)
+            self.assertEqual(getattr(reloaded_cfg._exp, "model", None), getattr(original_cfg._exp, "model", None))
+            self.assertEqual(hasattr(reloaded_cfg._exp, "modules"), hasattr(original_cfg._exp, "modules"))
+            # You can check more fields as needed
+
+            # Optionally, assert all top-level keys are the same
+            orig_keys = set(vars(original_cfg._exp).keys())
+            reload_keys = set(vars(reloaded_cfg._exp).keys())
+            self.assertEqual(orig_keys, reload_keys)
 
 
 if __name__ == "__main__":

--- a/tests/configs/test_config.py
+++ b/tests/configs/test_config.py
@@ -86,8 +86,8 @@ class TestPrimusParser(PrimusUT):
         Test that a config exported by PrimusConfig.export from a real YAML
         can be parsed back by PrimusParser.parse without loss or error.
         """
-        import tempfile, os
-        from primus.core.launcher.config import PrimusConfig
+        import os
+        import tempfile
 
         # Step 1: Load original config using parser
         original_args = argparse.Namespace(config="examples/megatron/exp_pretrain.yaml")
@@ -103,7 +103,9 @@ class TestPrimusParser(PrimusUT):
             reloaded_cfg = self.config_parser.parse(reload_args)
 
             # Step 4: Assert that some key fields match (e.g. model, modules)
-            self.assertEqual(getattr(reloaded_cfg._exp, "model", None), getattr(original_cfg._exp, "model", None))
+            self.assertEqual(
+                getattr(reloaded_cfg._exp, "model", None), getattr(original_cfg._exp, "model", None)
+            )
             self.assertEqual(hasattr(reloaded_cfg._exp, "modules"), hasattr(original_cfg._exp, "modules"))
             # You can check more fields as needed
 


### PR DESCRIPTION
# PR: Unify config/backend CLI & add config export support

## Summary
This PR streamlines how config and backend paths are handled across Primus CLI and examples. It also adds support for exporting the final merged config to YAML.

## Key Updates

### CLI Parser (`parser.py`)
- Add support for `--backend_path` and `--export_config`.
- Add `PrimusParser.export(path)` to dump merged config.
- Introduce `add_pretrain_parser(...)` and `load_primus_config(...)` helpers.

### Prepare Scripts
- `prepare_experiment.py` and backend `prepare.py` scripts support:
  - `--config` and optional `--backend_path`
  - Patch args now include `backend_path`
  - Use CLI arg > env var > default path fallback

### Training Scripts
- `run_pretrain.sh` simplified `PYTHONPATH` setup
- Auto-passes `BACKEND_PATH` to prepare
- `run_local_pretrain.sh` supports container envs: `MEGATRON_PATH`, `TORCHTITAN_PATH`, `BACKEND_PATH`

