### PR TITLE
feat(CLI): support sbatch mode and extract run_slurm_job.sh as unif…

### DIFF
--- a/examples/run_slurm_job.sh
+++ b/examples/run_slurm_job.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+#SBATCH --exclusive
+#SBATCH --cpus-per-task=128
+#SBATCH --ntasks-per-node=1
+#SBATCH --job-name=primus-job
+#SBATCH --output=logs/slurm-%j.out
+#SBATCH --error=logs/slurm-%j.err
+##SBATCH --nodes=2
+##SBATCH --partition=****
+##SBATCH --reservation=****
+
+###############################################################################
+## Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+##
+## See LICENSE for license information.
+###############################################################################
+
+
+###############################################################################
+# Usage Guide:
+#
+# This script supports running distributed training in 3 Slurm modes:
+#
+#   1. [Bash + srun] Run directly via:
+#        NNODES=2 CPUS_PER_TASK=256 PARTITION=xxx RESERVATION=xxx \
+#        bash run_test.sh benchmark gemm
+#
+#   2. [salloc] Allocate nodes interactively and run:
+#        salloc -N2 --cpus-per-task=256 --reservation=xxx
+#        bash run_test.sh benchmark gemm
+#
+#   3. [sbatch] Submit as a batch job:
+#        IMPORTANT: You MUST explicitly set SCRIPT_DIR in sbatch mode!
+#        Example:
+#           export SCRIPT_DIR=/path/to/scrips
+#           sbatch --nodes=2 --reservation=xxx run_test.sh benchmark gemm
+#
+# Supported ENV variables (can be passed inline):
+#   NNODES         - Number of nodes to use (default: 1)
+#   CPUS_PER_TASK  - CPUs per task for srun (default: 256)
+#   PARTITION      - Slurm partition name
+#   RESERVATION    - Reservation name
+#   NODELIST       - Optional comma-separated list of nodes
+#   MASTER_PORT    - Port used for torch.distributed (default: 12345)
+#   LOG_DIR        - Directory to save logs (default: ./logs)
+#   SCRIPT_DIR     - [REQUIRED for sbatch] Path to the directory containing run_local_job.sh
+#
+# Output:
+#   Logs will be saved to: ${LOG_DIR}/log_JOB-${JOB_ID}_${TIMESTAMP}.slurm.txt
+###############################################################################
+
+set -euo pipefail
+
+# for arg in "$@"; do
+#   if [[ "$arg" == --* ]]; then
+#     echo "$arg"
+#   fi
+# done
+
+# ARGS=("$@")  # 保留所有参数
+# i=0
+# while [ $i -lt ${#ARGS[@]} ]; do
+#   arg="${ARGS[$i]}"
+#   if [[ "$arg" == --* ]]; then
+#     next="${ARGS[$((i + 1))]:-}"
+#     if [[ "$next" == --* || -z "$next" ]]; then
+#       echo "$arg"
+#     else
+#       echo "$arg $next"
+#       ((i++))  # skip value
+#     fi
+#   fi
+#   ((i++))
+# done
+# echo "All -- arguments:"
+# for arg in "${ARGS[@]}"; do
+#   if [[ "$arg" == --* ]]; then
+#     echo "$arg"
+#   fi
+# done
+
+# ----------------- Default environment variables -----------------
+export MASTER_PORT="${MASTER_PORT:-12345}"
+export CPUS_PER_TASK="${CPUS_PER_TASK:-256}"
+export PARTITION="${PARTITION:-}"
+export RESERVATION="${RESERVATION:-}"
+
+export LOG_DIR="${LOG_DIR:-"./logs"}"
+mkdir -p "$LOG_DIR"
+
+export SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"
+
+# ----------------- Log file configuration -----------------
+JOB_ID="${SLURM_JOB_ID:-manual}"
+TIMESTAMP=$(date +%Y%m%d%H%M%S)
+export LOG_FILE="${LOG_FILE:-${LOG_DIR}/log_JOB-${JOB_ID}_${TIMESTAMP}}"
+
+
+launch_srun_with_args() {
+    local srun_args=("${!1}")  # Expand srun argument array from variable name
+    shift  # Remove array name from positional args
+
+    echo "[INFO] Launching srun: ${srun_args[*]}"
+
+    srun "${srun_args[@]}" bash -c "
+        readarray -t node_array < <(scontrol show hostnames \"\$SLURM_JOB_NODELIST\")
+        if [[ \"\$SLURM_NODEID\" = \"0\" ]]; then
+            echo \"========== Slurm cluster info ==========\"
+            echo \"SLURM_NODELIST: \${node_array[*]}\"
+            echo \"SLURM_NNODES: \${SLURM_NNODES}\"
+            echo \"SLURM_GPUS_ON_NODE: \${SLURM_GPUS_ON_NODE}\"
+            echo \"\"
+        fi
+        export MASTER_ADDR=\${node_array[0]}
+        export MASTER_PORT=\${MASTER_PORT}
+        export NNODES=\${SLURM_NNODES}
+        export NODE_RANK=\${SLURM_PROCID}
+        export GPUS_PER_NODE=\${SLURM_GPUS_ON_NODE}
+        export LOG_FILE=\${LOG_FILE}
+        bash \${SCRIPT_DIR}/run_local_pretrain.sh \"\$@\" 2>&1 | tee ${LOG_FILE}.slurm.txt
+    " bash "$@"
+}
+
+# ----------------- Scene 1: Outside Slurm (e.g., bash + srun) -----------------
+run_via_bash_srun() {
+    local srun_args=(
+        --exclusive
+        --ntasks-per-node=1
+        --cpus-per-task="$CPUS_PER_TASK"
+    )
+    export NNODES="${NNODES:-1}"
+    export NODELIST=${NODELIST:-}
+    [[ -n "$PARTITION" ]] && srun_args+=("--partition=$PARTITION")
+    [[ -n "$RESERVATION" ]] && srun_args+=("--reservation=$RESERVATION")
+    [[ -n "$NODELIST" ]] && srun_args+=("--nodelist=$NODELIST") || srun_args+=("-N" "$NNODES")
+
+    echo "[INFO] Launching outer srun: ${srun_args[*]}"
+    launch_srun_with_args srun_args[@] "$@"
+}
+
+# ----------------- Scene 2: Inside salloc shell -----------------
+run_within_salloc() {
+    export NNODES="${NNODES:-1}"
+    readarray -t node_array < <(scontrol show hostnames "$SLURM_JOB_NODELIST")
+    total_nodes="${#node_array[@]}"
+    local use_nodes="${NNODES:-$total_nodes}"
+
+    if (( use_nodes > total_nodes )); then
+        echo "[ERROR] Requested NNODES=$use_nodes exceeds allocated nodes $total_nodes"
+        exit 1
+    fi
+
+    selected_nodes=("${node_array[@]:0:$use_nodes}")
+    selected_nodelist=$(IFS=,; echo "${selected_nodes[*]}")
+
+    echo "[INFO] Using $use_nodes node(s): $selected_nodelist"
+    local srun_args=(
+        --exclusive
+        --ntasks-per-node=1
+        --cpus-per-task="$CPUS_PER_TASK"
+        -N "$use_nodes"
+        --nodelist="$selected_nodelist"
+    )
+
+    launch_srun_with_args srun_args[@] "$@"
+}
+
+# ----------------- Scene 3: Inside sbatch script -----------------
+run_within_sbatch() {
+    echo "[INFO] Detected sbatch session (JOB_ID=$SLURM_JOB_ID)."
+
+    readarray -t node_array < <(scontrol show hostnames "$SLURM_JOB_NODELIST")
+    total_nodes="${#node_array[@]}"
+    selected_nodes=("${node_array[@]}")
+    selected_nodelist=$(IFS=,; echo "${selected_nodes[*]}")
+
+    echo "[INFO] Using all allocated nodes ($total_nodes): $selected_nodelist"
+
+    local srun_args=(
+        --exclusive
+        --ntasks-per-node="$SLURM_NTASKS_PER_NODE"
+        --cpus-per-task="$SLURM_CPUS_PER_TASK"
+    )
+
+    launch_srun_with_args srun_args[@] "$@"
+}
+
+# ----------------- Entry: bash / salloc / sbatch -----------------
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    if [[ "${SLURM_STEP_ID:-}" == "4294967294" || "${SLURM_STEP_ID:-}" == "4294967290" ]]; then
+        echo "[INFO] Detected salloc session (interactive shell)"
+        run_within_salloc "$@"
+    else
+        echo "[INFO] Detected sbatch job (batch submission)"
+        run_within_sbatch "$@"
+    fi
+else
+    echo "[INFO] Not running under Slurm"
+    run_via_bash_srun "$@"
+fi

--- a/examples/run_slurm_pretrain.sh
+++ b/examples/run_slurm_pretrain.sh
@@ -5,68 +5,53 @@
 # See LICENSE for license information.
 ###############################################################################
 
-if [[ "$1" == "--help" || "$1" == "-h" ]]; then
-cat <<EOF
-Usage: run_slurm_pretrain.sh
+set -euo pipefail
 
-Launches a Primus distributed pretraining task on a Slurm cluster using Docker.
+export NNODES="${NNODES:-1}"
+# Optional: control whether to use sbatch or direct bash
+export USE_SBATCH="${USE_SBATCH:-0}"
 
-Requirements:
-  - Slurm job scheduler with 'srun'
-  - Docker or Podman runtime (for container execution)
-
-Optional Environment Variables:
-  NNODES          Number of nodes to use [default: 1]
-  MASTER_PORT     Master port [default: 12345]
-  LOG_DIR         Directory for log output [default: ./output]
-
-Example:
-  export DATA_PATH=/mnt/data
-  export EXP=examples/megatron/exp_pretrain.yaml
-  NNODES=2 bash run_slurm_pretrain.sh
-EOF
-exit 0
+# -------------------- EXP Check --------------------
+if [ -z "${EXP:-}" ]; then
+    echo "[ERROR] EXP must be specified (e.g., examples/megatron/exp_pretrain.yaml)." \
+         "Primus will use the configuration in EXP to train the model."
+    exit 1
 fi
 
-export MASTER_PORT=${MASTER_PORT:-12345}
-export NNODES=${NNODES:-1}
+# Ensure EXP file exists, otherwise exit with error
+if [ ! -f "${EXP}" ]; then
+    echo "[ERROR] The specified EXP file does not exist: '${EXP}'." \
+         "Primus will use the configuration in EXP to train the model."
+    exit 1
+fi
 
-SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+# -------------------- DATA_PATH Check --------------------
+if [ -z "${DATA_PATH:-}" ]; then
+    DATA_PATH="$(pwd)/data"
+    echo "[WARNING] DATA_PATH not specified. Defaulting to: ${DATA_PATH}"
 
-export LOG_DIR=${LOG_DIR:-"./output"}
-LOG_FILE="${LOG_DIR}/log_slurm_pretrain.txt"
-mkdir -p "$LOG_DIR"
+    if [ ! -d "${DATA_PATH}" ]; then
+        echo "[WARNING] DATA_PATH does not exist. Creating: ${DATA_PATH}"
+        mkdir -p "${DATA_PATH}"
+    fi
+fi
 
-srun -N "${NNODES}" \
-     --exclusive \
-     --ntasks-per-node=1 \
-     --cpus-per-task="${CPUS_PER_TASK:-256}" \
-     bash -c "
-          readarray -t node_array < <(scontrol show hostnames \"\$SLURM_JOB_NODELIST\")
-          if [ \"\$SLURM_NODEID\" = \"0\" ]; then
-              echo \"========== Slurm cluster info ==========\"
-              echo \"SLURM_NODELIST: \${node_array[*]}\"
-              echo \"SLURM_NNODES: \${SLURM_NNODES}\"
-              echo \"SLURM_GPUS_ON_NODE: \${SLURM_GPUS_ON_NODE}\"
-              echo \"\"
-          fi
-          export MASTER_ADDR=\${node_array[0]}
-          export MASTER_PORT=\${MASTER_PORT}
-          export NNODES=\${SLURM_NNODES}
-          export NODE_RANK=\${SLURM_PROCID}
-          export GPUS_PER_NODE=\${SLURM_GPUS_ON_NODE}
-          export HSA_NO_SCRATCH_RECLAIM=\${HSA_NO_SCRATCH_RECLAIM}
-          export NVTE_CK_USES_BWD_V3=\${NVTE_CK_USES_BWD_V3}
-          export NCCL_IB_HCA=\${NCCL_IB_HCA}
-          export NCCL_PXN_DISABLE=\${NCCL_PXN_DISABLE}
-          export NCCL_P2P_NET_CHUNKSIZE=\${NCCL_P2P_NET_CHUNKSIZE}
-          export GPU_MAX_HW_QUEUES=\${GPU_MAX_HW_QUEUES}
-          export GLOO_SOCKET_IFNAME=\${GLOO_SOCKET_IFNAME}
-          export NCCL_SOCKET_IFNAME=\${NCCL_SOCKET_IFNAME}
-          export REBUILD_BNXT=\${REBUILD_BNXT}
-          export MEGATRON_PATH=\${MEGATRON_PATH}
-          export TORCHTITAN_PATH=\${TORCHTITAN_PATH}
-          export BACKEND_PATH=\${BACKEND_PATH}
-          export PATH_TO_BNXT_TAR_PACKAGE=\${PATH_TO_BNXT_TAR_PACKAGE}
-          bash ${SCRIPT_DIR}/run_local_pretrain.sh \"\$@\" 2>&1 | tee ${LOG_FILE}
-     " bash "$@"
+# Slurm Launch
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+export SCRIPT_DIR
+export DATA_PATH
+bash "${SCRIPT_DIR}/run_slurm_job.sh" "$@"
+
+# Choose between sbatch and direct bash execution
+if [[ "${USE_SBATCH}" == "1" ]]; then
+    echo "[INFO] Launching with sbatch"
+    SBATCH_ARGS=(--nodes="$NNODES")
+    if [[ -n "${RESERVATION:-}" ]]; then
+        SBATCH_ARGS+=(--reservation="$RESERVATION")
+    fi
+    # Submit the job using sbatch
+    sbatch "${SBATCH_ARGS[@]}" "${SCRIPT_DIR}/run_slurm_job.sh" "$@"
+else
+    echo "[INFO] Launching directly with bash"
+    bash "${SCRIPT_DIR}/run_slurm_job.sh" "$@"
+fi


### PR DESCRIPTION
### 🧩 Summary

This PR introduces `sbatch` support for launching Primus training jobs via Slurm and extracts `run_slurm_job.sh` as a reusable entrypoint across different submission modes.

---

### ✅ Changes

- ✨ **Support `USE_SBATCH=1` to toggle sbatch submission**
  - Default behavior still uses `bash run_slurm_job.sh`
  - Setting `USE_SBATCH=1` triggers `sbatch` with dynamic argument forwarding
- 🔧 **Extracted `run_slurm_job.sh`** as a unified job script
  - Receives all forwarded CLI arguments (`"$@"`)
  - Designed to be used both in direct `bash` and `sbatch` modes
- 🧪 Added config and path checks:
  - Validate required `EXP` file exists
  - Auto-create `DATA_PATH` if not set
- 📤 All extra `--xxx` arguments are preserved and passed through

---

### 📂 Example Usage

```bash
# Direct bash mode (default)
EXP=examples/megatron/exp_pretrain.yaml bash examples/run_slurm_pretrain.sh --tag testA

# sbatch mode
USE_SBATCH=1 EXP=examples/megatron/exp_pretrain.yaml bash examples/run_slurm_pretrain.sh --tag testA