### PR TITLE
update log/wandb/tensorboard

### DIFF
--- a/primus/configs/modules/megatron/primus_megatron_module.yaml
+++ b/primus/configs/modules/megatron/primus_megatron_module.yaml
@@ -4,6 +4,7 @@ disable_tensorboard: true
 disable_wandb: true
 disable_compile_dependencies: true
 disable_profiler_activity_cpu: false
+use_rocm_mem_info: true
 
 # continue/finetune
 auto_continue_train: false

--- a/primus/core/utils/rocm_mem_info.py
+++ b/primus/core/utils/rocm_mem_info.py
@@ -1,0 +1,28 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+import subprocess
+
+
+def get_rocm_smi_mem_info(device_id: int):
+    try:
+        out = subprocess.check_output(["rocm-smi", "--showmeminfo", "vram", f"-d={device_id}"], text=True)
+    except FileNotFoundError:
+        raise RuntimeError("rocm-smi not found, please ensure ROCm is installed and in PATH")
+
+    # mem in Bytes
+    total_mem, used_mem = None, None
+    for line in out.splitlines():
+        if "Total Memory" in line:
+            total_mem = int(line.split(":")[-1].strip())
+        elif "Total Used Memory" in line:
+            used_mem = int(line.split(":")[-1].strip())
+
+    assert total_mem is not None
+    assert used_mem is not None
+    free_mem = total_mem - used_mem
+
+    return total_mem, used_mem, free_mem

--- a/primus/modules/trainer/megatron/trainer.py
+++ b/primus/modules/trainer/megatron/trainer.py
@@ -5,6 +5,7 @@
 ###############################################################################
 
 import dataclasses
+import gc
 import importlib.util
 import os
 import statistics


### PR DESCRIPTION
**New Argument**

* `use_rocm_mem_info`:

  * `true` → use memory info collected from **ROCm (rocm-smi)**
  * `false` → use memory info from **HIP (`hip.hipMemGetInfo`)**

**Motivation**
Previously, we only supported `hipMemGetInfo` for memory usage collection, but its reported value may differ from `rocm-smi`.
This PR adds an option to switch between the two sources, providing more flexibility for debugging and monitoring.

**Changes**

* Added a new argument `use_rocm_mem_info`.
* Updated memory info collection logic to use either ROCm or HIP depending on the argument.

---


log
- mem usage/free/total/usage_ratio


[20250825 13:42:35][rank-7/8][INFO ] [--------trainer.py:2154] :  iteration        5/       6 | consumed samples:           80 | elapsed time per iteration (ms): 1595.5/1630.1 | **rocm mem usage/free/total/usage_ratio: 99.07GB/92.92GB/191.98GB/51.60%** | throughput per GPU (TFLOP/s/GPU): 92.8/90.8 | tokens per GPU (tokens/s/GPU): 5134.5/5026.5 | learning rate: 1.464466E-06 | global batch size:    16 | lm loss: 9.732306E+00 | loss scale: 1.0 | grad norm: 10.682 | num zeros: 3143909632.0 | number of skipped iterations:   0 | number of nan iterations:   0 |

Add new metrics in wandb/tensorboard:
- throughput(tflops/sec/gpu)
- token_throughput(tokens/sec/gpu)
- rocm_used_mem(GB)
- rocm_free_mem(GB)
- rocm_total_mem(GB)
- rocm_mem_usage(%)

