### PR TITLE
turn on manual gc

### DIFF
--- a/primus/configs/modules/megatron/trainer_base.yaml
+++ b/primus/configs/modules/megatron/trainer_base.yaml
@@ -188,8 +188,8 @@ distribute_saved_activations: false
 checkpoint_activations: false # deprecated
 
 # garbage collection
-manual_gc: false
-manual_gc_interval: 0
+manual_gc: true # default false
+manual_gc_interval: 1 # int, default 0
 manual_gc_eval: true
 
 #data


### PR DESCRIPTION
Disable the threshold-based default garbage collector and trigger the garbage collection manually. Manual garbage collection helps to align the timing of the collection across ranks which mitigates the impact of CPU-associated jitters.
This is helpful for maintaining training performance stability in large-scale model training.